### PR TITLE
feat: allow custom helia config

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test": "vite build -c ./test/vite.config.js && test-browser-example test"
   },
   "dependencies": {
+    "@helia/block-brokers": "^3.0.4",
+    "@helia/routers": "^1.1.1",
     "@helia/verified-fetch": "^1.3.2",
     "@sgtpooki/file-type": "^1.0.1",
     "react": "^18.2.0",
@@ -22,6 +24,7 @@
     "@types/react": "^18.2.72",
     "@types/react-dom": "^18.2.22",
     "@vitejs/plugin-react": "^4.2.1",
+    "helia": "^4.2.6",
     "test-ipfs-example": "^1.0.0",
     "typescript": "^5.4.3",
     "vite": "^5.2.6"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,13 @@
 import { createVerifiedFetch } from '@helia/verified-fetch'
-import { createHelia } from 'helia'
+import { createHeliaHTTP } from '@helia/http'
 import { fileTypeFromBuffer } from '@sgtpooki/file-type'
 import { useCallback, useState } from 'react'
 import { Output } from './Output'
 import { helpText } from './constants'
 import { delegatedHTTPRouting, httpGatewayRouting } from '@helia/routers'
-import { bitswap, trustlessGateway } from '@helia/block-brokers'
+import { trustlessGateway } from '@helia/block-brokers'
 
-const helia = await createHelia({
+const helia = await createHeliaHTTP({
   routers: [
     delegatedHTTPRouting('http://delegated-ipfs.dev'), // find peers from gateway
     httpGatewayRouting(), // public gateway list
@@ -17,7 +17,6 @@ const helia = await createHelia({
   ],
   blockBrokers: [
     trustlessGateway(), // http fetching
-    bitswap() // may not need bitswap?
   ]
 })
 const verifiedFetch = await createVerifiedFetch(helia)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,26 @@
-import { verifiedFetch } from '@helia/verified-fetch'
+import { createVerifiedFetch } from '@helia/verified-fetch'
+import { createHelia } from 'helia'
 import { fileTypeFromBuffer } from '@sgtpooki/file-type'
 import { useCallback, useState } from 'react'
 import { Output } from './Output'
 import { helpText } from './constants'
+import { delegatedHTTPRouting, httpGatewayRouting } from '@helia/routers'
+import { bitswap, trustlessGateway } from '@helia/block-brokers'
+
+const helia = await createHelia({
+  routers: [
+    delegatedHTTPRouting('http://delegated-ipfs.dev'), // find peers from gateway
+    httpGatewayRouting(), // public gateway list
+    httpGatewayRouting({ // local/custom gateways
+      gateways: ['http://localhost:8080']
+    })
+  ],
+  blockBrokers: [
+    trustlessGateway(), // http fetching
+    bitswap() // may not need bitswap?
+  ]
+})
+const verifiedFetch = await createVerifiedFetch(helia)
 
 function App (): JSX.Element {
   const [path, setPath] = useState<string>('')

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,8 @@ import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
+  build: {
+    target: 'esnext'
+  }
 })


### PR DESCRIPTION
imports Helia directly and passes to verified fetch (you may want `@helia/http` instead of the HeliaP2P version..)

customizes the Helia instance with delegated routing, block brokers, and trustless gateway lists

adds comments to help explain things for non-Helia devs

note that helia/verified fetch are not yet codified in a completel "react-y" way, and are simply using top level await to be set

this should be fine for the majority of use cases, but when hot-reloading, you might experience issues. Just hard refresh page to instantiate a new instance.

You may want to add blockstore/datastore to the Helia instance to persist peerId?
